### PR TITLE
Changed maxLength prop type from string to number.

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -47,7 +47,7 @@ class ReactTags extends Component {
     classNames: PropTypes.object,
     name: PropTypes.string,
     id: PropTypes.string,
-    maxLength: PropTypes.string,
+    maxLength: PropTypes.number,
     inputValue: PropTypes.string,
     tags: PropTypes.arrayOf(
       PropTypes.shape({


### PR DESCRIPTION
maxLength requires a number in the docs but in the code a string is required